### PR TITLE
Implement experiments endpoint

### DIFF
--- a/deployment/ingress.yml
+++ b/deployment/ingress.yml
@@ -2,8 +2,6 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: warehouse-to-model
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   tls:
   - hosts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - FLASK_APP=src/warehouse_to_model/wsgi.py
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:*}
       - SENTRY_DSN=${SENTRY_DSN}
+      - WAREHOUSE_API=${WAREHOUSE_API:-http://warehouse:8000}
     command: gunicorn -c gunicorn.py warehouse_to_model.wsgi:app
 
 # Additional services that the `web` service `depends_on` should usually only

--- a/src/warehouse_to_model/app.py
+++ b/src/warehouse_to_model/app.py
@@ -47,7 +47,6 @@ def init_app(application, interface):
         sentry.init_app(application)
 
     # Add routes and resources.
-    from warehouse_to_model import resources
     interface.prefix = application.config['SERVICE_URL']
     interface._doc = f"{application.config['SERVICE_URL']}/"
     interface.init_app(application)

--- a/src/warehouse_to_model/app.py
+++ b/src/warehouse_to_model/app.py
@@ -50,7 +50,6 @@ def init_app(application, interface):
     from warehouse_to_model import resources
     interface.prefix = application.config['SERVICE_URL']
     interface._doc = f"{application.config['SERVICE_URL']}/"
-    interface.add_resource(resources.HelloWorld, "/")
     interface.init_app(application)
 
     # Redirect requests for the root url to the service url

--- a/src/warehouse_to_model/app.py
+++ b/src/warehouse_to_model/app.py
@@ -18,7 +18,7 @@
 import logging
 import logging.config
 
-from flask import Flask
+from flask import Flask, redirect
 from flask_cors import CORS
 from flask_restplus import Api
 from raven.contrib.flask import Sentry

--- a/src/warehouse_to_model/app.py
+++ b/src/warehouse_to_model/app.py
@@ -48,6 +48,8 @@ def init_app(application, interface):
 
     # Add routes and resources.
     from warehouse_to_model import resources
+    interface.prefix = application.config['SERVICE_URL']
+    interface._doc = f"{application.config['SERVICE_URL']}/"
     interface.add_resource(resources.HelloWorld, "/")
     interface.init_app(application)
 

--- a/src/warehouse_to_model/app.py
+++ b/src/warehouse_to_model/app.py
@@ -53,5 +53,10 @@ def init_app(application, interface):
     interface.add_resource(resources.HelloWorld, "/")
     interface.init_app(application)
 
+    # Redirect requests for the root url to the service url
+    @application.route("/")
+    def root_redirect():
+        return redirect(f"{application.config['SERVICE_URL']}")
+
     # Add CORS information for all resources.
     CORS(application)

--- a/src/warehouse_to_model/decorators.py
+++ b/src/warehouse_to_model/decorators.py
@@ -30,7 +30,6 @@ def forward_jwt(f):
 
     Use this session only with internal HTTP services.
     """
-
     @wraps(f)
     def wrap(*args, **kwargs):
         session = requests.Session()

--- a/src/warehouse_to_model/decorators.py
+++ b/src/warehouse_to_model/decorators.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2018, Novo Nordisk Foundation Center for Biosustainability,
+# Technical University of Denmark.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import wraps
+
+from flask import request
+import requests
+
+
+def forward_jwt(f):
+    """
+    Add a requests session with the Authorization header forwarded.
+
+    Use on functions that make requests to third party API services. This will
+    call the function yield an extra keyword argument `session`, which is a
+    requests session that has the Authorization header set with the same value
+    as provided by the original client.
+
+    Use this session only with internal HTTP services.
+    """
+
+    @wraps(f)
+    def wrap(*args, **kwargs):
+        session = requests.Session()
+        if 'Authorization' in request.headers:
+            session.headers.update({
+                'Authorization': request.headers['Authorization']})
+        return f(*args, **kwargs, session=session)
+    return wrap

--- a/src/warehouse_to_model/decorators.py
+++ b/src/warehouse_to_model/decorators.py
@@ -15,8 +15,8 @@
 
 from functools import wraps
 
-from flask import request
 import requests
+from flask import request
 
 
 def forward_jwt(f):

--- a/src/warehouse_to_model/decorators.py
+++ b/src/warehouse_to_model/decorators.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Decorators."""
+
 from functools import wraps
 
 import requests

--- a/src/warehouse_to_model/resources.py
+++ b/src/warehouse_to_model/resources.py
@@ -17,13 +17,10 @@
 
 from flask_restplus import Resource
 
-from warehouse_to_model.app import app
+from warehouse_to_model.app import api, app
 
 
-class HelloWorld(Resource):
-    """Example API resource."""
-
+@api.route('/experiments')
+class Experiments(Resource):
     def get(self):
-        """Shout out loud."""
-        app.logger.debug("I ran!")
-        return "Hello World!"
+        return requests.get(f"{app.config['WAREHOUSE_API']}/experiments").json()

--- a/src/warehouse_to_model/resources.py
+++ b/src/warehouse_to_model/resources.py
@@ -23,6 +23,9 @@ from warehouse_to_model.decorators import forward_jwt
 
 @api.route('/experiments')
 class Experiments(Resource):
+    """Retrieve accessible experiments from the data warehouse."""
+
     @forward_jwt
     def get(self, session):
+        """Get experiments."""
         return session.get(f"{app.config['WAREHOUSE_API']}/experiments").json()

--- a/src/warehouse_to_model/resources.py
+++ b/src/warehouse_to_model/resources.py
@@ -18,9 +18,11 @@
 from flask_restplus import Resource
 
 from warehouse_to_model.app import api, app
+from warehouse_to_model.decorators import forward_jwt
 
 
 @api.route('/experiments')
 class Experiments(Resource):
-    def get(self):
-        return requests.get(f"{app.config['WAREHOUSE_API']}/experiments").json()
+    @forward_jwt
+    def get(self, session):
+        return session.get(f"{app.config['WAREHOUSE_API']}/experiments").json()

--- a/src/warehouse_to_model/settings.py
+++ b/src/warehouse_to_model/settings.py
@@ -47,6 +47,7 @@ class Default:
         self.DEBUG = True
         self.SECRET_KEY = os.urandom(24)
         self.BUNDLE_ERRORS = True
+        self.SERVICE_URL = '/warehouse-to-model'
         self.CORS_ORIGINS = os.environ['ALLOWED_ORIGINS'].split(",")
         self.SENTRY_DSN = os.environ.get('SENTRY_DSN')
         self.LOGGING = {

--- a/src/warehouse_to_model/settings.py
+++ b/src/warehouse_to_model/settings.py
@@ -50,6 +50,7 @@ class Default:
         self.SERVICE_URL = '/warehouse-to-model'
         self.CORS_ORIGINS = os.environ['ALLOWED_ORIGINS'].split(",")
         self.SENTRY_DSN = os.environ.get('SENTRY_DSN')
+        self.WAREHOUSE_API = os.environ['WAREHOUSE_API']
         self.LOGGING = {
             'version': 1,
             'disable_existing_loggers': False,

--- a/src/warehouse_to_model/wsgi.py
+++ b/src/warehouse_to_model/wsgi.py
@@ -15,7 +15,8 @@
 
 """Prepare the application for use by the WSGI server (gunicorn)."""
 
-from warehouse_to_model.app import api, app, init_app
+from warehouse_to_model.app import app, init_app
+from warehouse_to_model.resources import api
 
 
 init_app(app, api)

--- a/tests/test_integration/test_openapi_docs.py
+++ b/tests/test_integration/test_openapi_docs.py
@@ -16,8 +16,12 @@
 """Test expected functioning of the OpenAPI docs endpoints."""
 
 
-def test_docs(client):
-    """Expect the OpenAPI docs to be served at root."""
-    resp = client.get("/")
+def test_docs(app, client):
+    """Expect the OpenAPI docs to be served as HTML and JSON."""
+    resp = client.get(f"{app.config['SERVICE_URL']}/")
     assert resp.status_code == 200
     assert resp.content_type == "text/html; charset=utf-8"
+
+    resp = client.get(f"{app.config['SERVICE_URL']}/swagger.json")
+    assert resp.status_code == 200
+    assert resp.content_type == "application/json"


### PR DESCRIPTION
I'm requesting an early review on the API implementation to get feedback on two specific changes:

* The app is no longer agnostic about the service url prefix (e.g. `/warehouse-to-model`). This is to support the rendered swagger docs - see f.ex. https://api-staging.dd-decaf.eu/warehouse/ which does not work right now.
* JWT is forwarded to third party services by using a decorator which provides a configured requests session.